### PR TITLE
Also return compliant when value does not exist

### DIFF
--- a/Detect_OfficeMgmtCOM.ps1
+++ b/Detect_OfficeMgmtCOM.ps1
@@ -4,11 +4,16 @@ $Type = "DWORD"
 $Value = 0
 
 Try {
-    $Registry = Get-ItemProperty -Path $Path -Name $Name -ErrorAction Stop | Select-Object -ExpandProperty $Name
+    $Registry = Get-ItemProperty -Path $Path -Name $Name -ErrorAction SilentlyContinue | Select-Object -ExpandProperty $Name
     If ($Registry -eq $Value) {
         Write-Output "Compliant"
         Exit 0
     }
+    ElseIf ($Registry -eq $null) {
+        Write-Output "Compliant"
+        Exit 0
+    }
+    
     Write-Warning "Not Compliant"
     Exit 1
 } 


### PR DESCRIPTION
If a computer has never been set to have configmgr manage Office 365 updates, this registry key may not exist.  In that case, the remediation script should not run.  If the script doesn't check for a null value, the remediation script will run but error when it tries to update a value that doesn't exist.